### PR TITLE
Improved to latest version of Swift and tested on iOS 16

### DIFF
--- a/Sharing/ViewModels/ViewModel.swift
+++ b/Sharing/ViewModels/ViewModel.swift
@@ -82,11 +82,16 @@ final class ViewModel: ObservableObject {
     ///   - phoneNumber: Phone number of the contact.
     func addContact(name: String, phoneNumber: String) async throws {
         let id = CKRecord.ID(zoneID: recordZone.zoneID)
-        let contactRecord = CKRecord(recordType: "Contact", recordID: id)
+        let contactRecord = CKRecord(recordType: "SharedContact", recordID: id)
         contactRecord["name"] = name
         contactRecord["phoneNumber"] = phoneNumber
 
-        try await database.save(contactRecord)
+        do {
+            try await database.save(contactRecord)
+        } catch {
+            debugPrint("ERROR: Failed to save new Contact: \(error)")
+            throw error
+        }
     }
 
     /// Fetches an existing `CKShare` on a Contact record, or creates a new one in preparation to share a Contact with another user.

--- a/Sharing/Views/ContentView.swift
+++ b/Sharing/Views/ContentView.swift
@@ -149,7 +149,7 @@ struct ContentView_Previews: PreviewProvider {
             id: UUID().uuidString,
             name: "John Appleseed",
             phoneNumber: "(888) 555-5512",
-            associatedRecord: CKRecord(recordType: "Contact")
+            associatedRecord: CKRecord(recordType: "SharedContact")
         )
     ]
 


### PR DESCRIPTION
Changed name of record field to allow test along other ck samples (which may use same field but with different payload type).